### PR TITLE
feat: Unify chat API services and add VLLM config placeholders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,169 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. This document also outlines best practices for working with Claude Code to ensure efficient and successful software development tasks.
+
+## Task Management
+
+For complex or multi-step tasks, Claude Code will use:
+*   **TodoWrite**: To create a structured task list, breaking down the work into manageable steps. This provides clarity on the plan and allows for tracking progress.
+*   **TodoRead**: To review the current list of tasks and their status, ensuring alignment and that all objectives are being addressed.
+
+## File Handling and Reading
+
+Understanding file content is crucial before making modifications.
+
+1.  **Targeted Information Retrieval**:
+    *   When searching for specific content, patterns, or definitions within a codebase, prefer using search tools like `Grep` or `Task` (with a focused search prompt). This is more efficient than reading entire files.
+
+2.  **Reading File Content**:
+    *   **Small to Medium Files**: For files where full context is needed or that are not excessively large, the `Read` tool can be used to retrieve the entire content.
+    *   **Large File Strategy**:
+        1.  **Assess Size**: Before reading a potentially large file, its size should be determined (e.g., using `ls -l` via the `Bash` tool or by an initial `Read` with a small `limit` to observe if content is truncated).
+        2.  **Chunked Reading**: If a file is large (e.g., over a few thousand lines), it should be read in manageable chunks (e.g., 1000-2000 lines at a time) using the `offset` and `limit` parameters of the `Read` tool. This ensures all content can be processed without issues.
+    *   Always ensure that the file path provided to `Read` is absolute.
+
+## File Editing
+
+Precision is key for successful file edits. The following strategies lead to reliable modifications:
+
+1.  **Pre-Edit Read**: **Always** use the `Read` tool to fetch the content of the file *immediately before* attempting any `Edit` or `MultiEdit` operation. This ensures modifications are based on the absolute latest version of the file.
+
+2.  **Constructing `old_string` (The text to be replaced)**:
+    *   **Exact Match**: The `old_string` must be an *exact* character-for-character match of the segment in the file you intend to replace. This includes all whitespace (spaces, tabs, newlines) and special characters.
+    *   **No Read Artifacts**: Crucially, do *not* include any formatting artifacts from the `Read` tool's output (e.g., `cat -n` style line numbers or display-only leading tabs) in the `old_string`. It must only contain the literal characters as they exist in the raw file.
+    *   **Sufficient Context & Uniqueness**: Provide enough context (surrounding lines) in `old_string` to make it uniquely identifiable at the intended edit location. The "Anchor on a Known Good Line" strategy is preferred: `old_string` is a larger, unique block of text surrounding the change or insertion point. This is highly reliable.
+
+3.  **Constructing `new_string` (The replacement text)**:
+    *   **Exact Representation**: The `new_string` must accurately represent the desired state of the code, including correct indentation, whitespace, and newlines.
+    *   **No Read Artifacts**: As with `old_string`, ensure `new_string` does *not* contain any `Read` tool output artifacts.
+
+4.  **Choosing the Right Editing Tool**:
+    *   **`Edit` Tool**: Suitable for a single, well-defined replacement in a file.
+    *   **`MultiEdit` Tool**: Preferred when multiple changes are needed within the same file. Edits are applied sequentially, with each subsequent edit operating on the result of the previous one. This tool is highly effective for complex modifications.
+
+5.  **Verification**:
+    *   The success confirmation from the `Edit` or `MultiEdit` tool (especially if `expected_replacements` is used and matches) is the primary indicator that the change was made.
+    *   If further visual confirmation is needed, use the `Read` tool with `offset` and `limit` parameters to view only the specific section of the file that was changed, rather than re-reading the entire file.
+
+### Reliable Code Insertion with MultiEdit
+
+When inserting larger blocks of new code (e.g., multiple functions or methods) where a simple `old_string` might be fragile due to surrounding code, the following `MultiEdit` strategy can be more robust:
+
+1.  **First Edit - Targeted Insertion Point**: For the primary code block you want to insert (e.g., new methods within a class), identify a short, unique, and stable line of code immediately *after* your desired insertion point. Use this stable line as the `old_string`.
+    *   The `new_string` will consist of your new block of code, followed by a newline, and then the original `old_string` (the stable line you matched on).
+    *   Example: If inserting methods into a class, the `old_string` might be the closing brace `}` of the class, or a comment that directly follows the class.
+
+2.  **Second Edit (Optional) - Ancillary Code**: If there's another, smaller piece of related code to insert (e.g., a function call within an existing method, or an import statement), perform this as a separate, more straightforward edit within the `MultiEdit` call. This edit usually has a more clearly defined and less ambiguous `old_string`.
+
+**Rationale**:
+*   By anchoring the main insertion on a very stable, unique line *after* the insertion point and prepending the new code to it, you reduce the risk of `old_string` mismatches caused by subtle variations in the code *before* the insertion point.
+*   Keeping ancillary edits separate allows them to succeed even if the main insertion point is complex, as they often target simpler, more reliable `old_string` patterns.
+*   This approach leverages `MultiEdit`'s sequential application of changes effectively.
+
+**Example Scenario**: Adding new methods to a class and a call to one of these new methods elsewhere.
+*   **Edit 1**: Insert the new methods. `old_string` is the class's closing brace `}`. `new_string` is `
+    [new methods code]
+    }`.
+*   **Edit 2**: Insert the call to a new method. `old_string` is `// existing line before call`. `new_string` is `// existing line before call
+    this.newMethodCall();`.
+
+This method provides a balance between precise editing and handling larger code insertions reliably when direct `old_string` matches for the entire new block are problematic.
+
+## Handling Large Files for Incremental Refactoring
+
+When refactoring large files incrementally rather than rewriting them completely:
+
+1. **Initial Exploration and Planning**:
+   * Begin with targeted searches using `Grep` to locate specific patterns or sections within the file.
+   * Use `Bash` commands like `grep -n "pattern" file` to find line numbers for specific areas of interest.
+   * Create a clear mental model of the file structure before proceeding with edits.
+
+2. **Chunked Reading for Large Files**:
+   * For files too large to read at once, use multiple `Read` operations with different `offset` and `limit` parameters.
+   * Read sequential chunks to build a complete understanding of the file.
+   * Use `Grep` to pinpoint key sections, then read just those sections with targeted `offset` parameters.
+
+3. **Finding Key Implementation Sections**:
+   * Use `Bash` commands with `grep -A N` (to show N lines after a match) or `grep -B N` (to show N lines before) to locate function or method implementations.
+   * Example: `grep -n "function findTagBoundaries" -A 20 filename.js` to see the first 20 lines of a function.
+
+4. **Pattern-Based Replacement Strategy**:
+   * Identify common patterns that need to be replaced across the file.
+   * Use the `Bash` tool with `sed` for quick previews of potential replacements.
+   * Example: `sed -n "s/oldPattern/newPattern/gp" filename.js` to preview changes without making them.
+
+5. **Sequential Selective Edits**:
+   * Target specific sections or patterns one at a time rather than attempting a complete rewrite.
+   * Focus on clearest/simplest cases first to establish a pattern of successful edits.
+   * Use `Edit` for well-defined single changes within the file.
+
+6. **Batch Similar Changes Together**:
+   * Group similar types of changes (e.g., all references to a particular function or variable).
+   * Use `Bash` with `sed` to preview the scope of batch changes: `grep -n "pattern" filename.js | wc -l`
+   * For systematic changes across a file, consider using `sed` through the `Bash` tool: `sed -i "s/oldPattern/newPattern/g" filename.js`
+
+7. **Incremental Verification**:
+   * After each set of changes, verify the specific sections that were modified.
+   * For critical components, read the surrounding context to ensure the changes integrate correctly.
+   * Validate that each change maintains the file's structure and logic before proceeding to the next.
+
+8. **Progress Tracking for Large Refactors**:
+   * Use the `TodoWrite` tool to track which sections or patterns have been updated.
+   * Create a checklist of all required changes and mark them off as they're completed.
+   * Record any sections that require special attention or that couldn't be automatically refactored.
+
+## Commit Messages
+
+When Claude Code generates commit messages on your behalf:
+*   The `Co-Authored-By: Claude <noreply@anthropic.com>` line will **not** be included.
+*   The `🤖 Generated with [Claude Code](https://claude.ai/code)` line will **not** be included.
+
+## General Interaction
+
+Claude Code will directly apply proposed changes and modifications using the available tools, rather than describing them and asking you to implement them manually. This ensures a more efficient and direct workflow.
+
+## Common Commands
+
+### Setup
+- Install dependencies: `uv sync` (This is preferred. `pip install -r requirements.txt` is also mentioned.)
+
+### Running the Application
+- Start the Flask application: `python run.py`
+- Expose the local application to the internet (requires ngrok setup): `ngrok http 8000 --domain your-domain.ngrok-free.app` (Replace `your-domain.ngrok-free.app` with your actual ngrok static domain)
+
+## Code Architecture
+
+This project is a WhatsApp bot built with Python and Flask, using the Meta Cloud API.
+
+### Project Structure Overview (`app/` directory)
+The application follows the Flask Factory Pattern.
+
+- **`app/__init__.py`**: Initializes the Flask app using the `create_app` factory function. This allows for creating multiple instances of the app (e.g., for testing).
+- **`app/config.py`**: Manages configurations and settings for the Flask application. Environment-specific variables and secrets are loaded and accessed here.
+- **`app/decorators/`**: Contains Python decorators.
+    - `security.py`: Houses security-related decorators, such as `signature_required` for validating incoming WhatsApp webhook requests.
+- **`app/services/`**: Contains services that interact with external APIs.
+    - `openai_service.py`: Handles integration with a configurable chat API provider (e.g., public OpenAI, Azure OpenAI) for generating AI responses. Behavior is controlled by the `CHAT_API_PROVIDER` environment variable.
+    - `azure_openai_service.py`: (This file has been consolidated into `openai_service.py` and is now redundant).
+- **`app/utils/`**: Utility functions and helpers.
+    - `whatsapp_utils.py`: Contains utility functions for handling WhatsApp-related operations, including processing incoming messages and formatting responses.
+- **`app/views.py`**: Defines the main blueprint for the app, where API endpoints (routes) are located. This primarily handles the `/webhook` endpoint for receiving messages from WhatsApp.
+
+### Main Files (Root Directory)
+- **`run.py`**: The entry point to run the Flask application.
+- **`example.env`**: Template for environment variables. A `.env` file should be created based on this.
+- **`pyproject.toml`**: Defines project metadata and dependencies.
+
+### Key Functionality
+1.  **Webhook Handling**: The application receives WhatsApp messages via a webhook configured in the Meta Developer portal. The `/webhook` endpoint in `app/views.py` processes these incoming messages.
+2.  **Security**: Webhook requests are validated using a signature check implemented in `app/decorators/security.py`.
+3.  **Message Processing**: Incoming messages are processed by `whatsapp_utils.py`.
+4.  **AI Integration**: `openai_service.py` is used to connect to an AI model to generate responses. The specific provider (e.g., public OpenAI, Azure OpenAI) is determined by the `CHAT_API_PROVIDER` environment variable. The `generate_response()` function in `whatsapp_utils.py` typically calls this service.
+5.  **Configuration**: Application secrets (API keys, tokens, etc.) are managed via environment variables, loaded in `app/config.py`.
+
+### Development Workflow
+1.  Set up environment variables in a `.env` file (based on `example.env`).
+2.  Install dependencies using `uv sync`.
+3.  Run the Flask application locally using `python run.py`.
+4.  Use ngrok to expose the local server to the internet so Meta's servers can send webhook events. The ngrok URL is configured in the Meta App Dashboard.
+5.  Test by sending messages to the configured WhatsApp number.

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -1,48 +1,117 @@
 """
 openai_service.py
 -----------------
-Exports `generate_response()` for the WhatsApp bot but uses the *public*
-OpenAI API (gpt\u20113.5\u2011turbo, gpt\u20114\u2011turbo, etc.) through the official `openai`
-package (\u22651.0).
+Exports `generate_response()` for the WhatsApp bot.
+Uses a configurable chat API provider (e.g., public OpenAI, Azure OpenAI),
+selected via the CHAT_API_PROVIDER environment variable.
 
 Environment variables
 ---------------------
-OPENAI_API_KEY        \u2013 required
-OPENAI_MODEL_NAME     \u2013 required (e.g. gpt-3.5-turbo, gpt-4o-mini, ...)
-OPENAI_API_BASE       \u2013 optional, override if using a proxy / mirror
+CHAT_API_PROVIDER: "OPENAI" or "AZURE" (required, defaults to "OPENAI")
+                     Determines which chat API service to use.
+
+If CHAT_API_PROVIDER="OPENAI":
+  OPENAI_API_KEY        – required
+  OPENAI_MODEL_NAME     – required (e.g. gpt-3.5-turbo, gpt-4o-mini, ...)
+  OPENAI_API_BASE       – optional, override if using a proxy / mirror
+  OPENAI_EMBEDDING_MODEL_NAME – optional, defaults to "text-embedding-3-small"
+
+If CHAT_API_PROVIDER="AZURE":
+  AZURE_OPENAI_ENDPOINT         – required (https://<resource>.openai.azure.com)
+  AZURE_OPENAI_API_KEY          – required (key from the portal)
+  AZURE_OPENAI_DEPLOYMENT_NAME  – required (chat model deployment, e.g. gpt4-turbo)
+  AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME – optional, if you use embeddings (defaults to chat deployment name)
+  AZURE_OPENAI_API_VERSION      – optional, default "2024-02-15-preview"
+
+Future providers (e.g., local vLLM) might require CHAT_API_PROVIDER="VLLM"
+and specific variables like VLLM_API_BASE and VLLM_MODEL_NAME.
 """
 
 from __future__ import annotations
 
 import os
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from dotenv import load_dotenv
-from openai import OpenAI
+from openai import OpenAI, AzureOpenAI # Import both
 
 load_dotenv()
 
-# Client initialisation
-_api_key = os.getenv("OPENAI_API_KEY")
-_model_name = os.getenv("OPENAI_MODEL_NAME")  # e.g. gpt-3.5-turbo
-_api_base = os.getenv("OPENAI_API_BASE")  # optional
+# ----------------------------------------------------------------------
+#   Client Initialization (conditional based on provider)
+# ----------------------------------------------------------------------
+_client: Union[OpenAI, AzureOpenAI] # Type hint for the client object
+_chat_model_or_deployment_id: str
+_embedding_model_or_deployment_id: str
 
-if not (_api_key and _model_name):
-    raise RuntimeError(
-        "OPENAI_API_KEY and OPENAI_MODEL_NAME environment variables must be set."
+CHAT_API_PROVIDER = os.getenv("CHAT_API_PROVIDER", "OPENAI").upper()
+
+if CHAT_API_PROVIDER == "AZURE":
+    _endpoint = os.getenv("AZURE_OPENAI_ENDPOINT", "").rstrip("/")
+    _api_key = os.getenv("AZURE_OPENAI_API_KEY")
+    _api_version = os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-15-preview")
+    _chat_deployment_name = os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+
+    if not (_endpoint and _api_key and _chat_deployment_name):
+        raise RuntimeError(
+            "For CHAT_API_PROVIDER='AZURE', AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, and "
+            "AZURE_OPENAI_DEPLOYMENT_NAME must be set."
+        )
+
+    _client = AzureOpenAI(
+        api_key=_api_key,
+        api_version=_api_version,
+        azure_endpoint=_endpoint,
+    )
+    _chat_model_or_deployment_id = _chat_deployment_name
+    _embedding_model_or_deployment_id = os.getenv(
+        "AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME", _chat_deployment_name # Fallback to chat deployment
+    )
+elif CHAT_API_PROVIDER == "OPENAI":
+    _api_key = os.getenv("OPENAI_API_KEY")
+    _model_name = os.getenv("OPENAI_MODEL_NAME")
+    _api_base = os.getenv("OPENAI_API_BASE") # optional
+
+    if not (_api_key and _model_name):
+        raise RuntimeError(
+            "For CHAT_API_PROVIDER='OPENAI', OPENAI_API_KEY and OPENAI_MODEL_NAME "
+            "environment variables must be set."
+        )
+
+    _client = OpenAI(
+        api_key=_api_key,
+        base_url=_api_base or None, # keeps default if unset
+    )
+    _chat_model_or_deployment_id = _model_name
+    _embedding_model_or_deployment_id = os.getenv(
+        "OPENAI_EMBEDDING_MODEL_NAME", "text-embedding-3-small"
+    )
+# Example for a future VLLM provider (illustrative)
+# elif CHAT_API_PROVIDER == "VLLM":
+# _api_base = os.getenv("VLLM_API_BASE") # e.g., http://localhost:8000/v1
+# _model_name = os.getenv("VLLM_MODEL_NAME") # e.g., mistralai/Mistral-7B-Instruct-v0.1
+# if not (_api_base and _model_name):
+# raise RuntimeError(
+#             "For CHAT_API_PROVIDER='VLLM', VLLM_API_BASE and VLLM_MODEL_NAME must be set."
+# )
+# _client = OpenAI(
+# api_key="DUMMY_KEY_IF_NOT_NEEDED", # VLLM might not need a key
+# base_url=_api_base,
+# )
+# _chat_model_or_deployment_id = _model_name
+#     _embedding_model_or_deployment_id = os.getenv("VLLM_EMBEDDING_MODEL_NAME", _model_name)
+else:
+    raise ValueError(
+        f"Invalid CHAT_API_PROVIDER: '{CHAT_API_PROVIDER}'. "
+        "Supported values are 'OPENAI' or 'AZURE'." # Update if VLLM is added
     )
 
-# Construct the client (base_url only if provided)
-_client = OpenAI(
-    api_key=_api_key,
-    base_url=_api_base or None,  # keeps default if unset
-)
-
-# Per-contact conversation buffers
+# ----------------------------------------------------------------------
+#   In-memory conversation buffer (common logic)
+# ----------------------------------------------------------------------
 _CONV_HISTORY: Dict[str, List[Dict[str, str]]] = defaultdict(list)
 _MAX_TURNS = 12  # keep roughly the last 12 user/assistant pairs
-
 
 def _append_to_history(wa_id: str, role: str, content: str) -> None:
     """Add a message to history and discard the oldest if buffer too big."""
@@ -51,8 +120,9 @@ def _append_to_history(wa_id: str, role: str, content: str) -> None:
     if excess > 0:
         _CONV_HISTORY[wa_id] = _CONV_HISTORY[wa_id][excess:]
 
-
-# Public API
+# ----------------------------------------------------------------------
+#   Public API (common logic, uses initialized client and model/deployment ID)
+# ----------------------------------------------------------------------
 def generate_response(
     message_body: str,
     wa_id: str,
@@ -61,6 +131,7 @@ def generate_response(
 ) -> str:
     """
     Generate an assistant reply for the WhatsApp user identified by *wa_id*.
+    Uses the configured chat API service (public OpenAI, Azure OpenAI, etc.).
     """
     # 1) decide / update system prompt
     if system_message is None:
@@ -77,9 +148,9 @@ def generate_response(
     # 2) add user message
     _append_to_history(wa_id, "user", message_body)
 
-    # 3) call OpenAI
+    # 3) call the configured Chat API
     response = _client.chat.completions.create(
-        model=_model_name,
+        model=_chat_model_or_deployment_id, # Use the unified variable
         messages=_CONV_HISTORY[wa_id],
         temperature=0.7,
         max_tokens=512,
@@ -92,17 +163,16 @@ def generate_response(
 
     return assistant_text
 
-
 # -----------------------------------------------------------------
-# Optional embeddings helper (parity with earlier version)
+# Optional embeddings helper (common logic)
 # -----------------------------------------------------------------
-_embedding_model = os.getenv("OPENAI_EMBEDDING_MODEL_NAME", "text-embedding-3-small")
-
-
 def embed(text: str) -> List[float]:
     """
     Return an embedding vector for *text*. Not used by WhatsApp bot but
-    provided for completeness.
+    provided for completeness. Uses the configured chat API service.
     """
-    resp = _client.embeddings.create(model=_embedding_model, input=[text])
+    resp = _client.embeddings.create(
+        model=_embedding_model_or_deployment_id, # Use the unified variable
+        input=[text]
+    )
     return resp.data[0].embedding

--- a/example.env
+++ b/example.env
@@ -15,7 +15,7 @@ VERIFY_TOKEN=""
 # ---------------------------------------------------------------------------
 # Chat API Provider Configuration
 # ---------------------------------------------------------------------------
-# Determines which chat API service to use. Options: "OPENAI", "AZURE".
+# Determines which chat API service to use. Options: "OPENAI", "AZURE", "VLLM".
 # Defaults to "OPENAI" if not set.
 CHAT_API_PROVIDER="OPENAI"
 
@@ -33,5 +33,8 @@ AZURE_OPENAI_DEPLOYMENT_NAME="" # Required (Name of your chat model deployment, 
 AZURE_OPENAI_API_VERSION="2024-02-15-preview" # Optional: API version, defaults to 2024-02-15-preview
 AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME="" # Optional: Name of your embedding model deployment (defaults to chat deployment name if not set)
 
-# Note: For a local vLLM setup (future), you might set CHAT_API_PROVIDER="VLLM"
-# and add variables like VLLM_API_BASE="http://localhost:8000/v1" and VLLM_MODEL_NAME="your-model".
+# --- Local vLLM Configuration (if CHAT_API_PROVIDER="VLLM") ---
+# VLLM_API_BASE="http://localhost:8000/v1"  # Required: Base URL of your vLLM server (OpenAI-compatible API endpoint)
+# VLLM_MODEL_NAME=""                        # Required: Model identifier used by your vLLM server
+# VLLM_API_KEY=""                           # Optional: API key if your vLLM server requires one (often not needed or can be a dummy value)
+# VLLM_EMBEDDING_MODEL_NAME=""              # Optional: Model for embeddings, if different from chat model

--- a/example.env
+++ b/example.env
@@ -1,23 +1,37 @@
-
+# WhatsApp Cloud API Configuration
 # This token expires after 24 hours. You can get a new one from the your Meta App Dashboard > API Setup
 # Or you can create an access token at the System User level from the Meta Business Settings: https://business.facebook.com/settings/system-users
-
 ACCESS_TOKEN=""
 
 APP_ID=""
 APP_SECRET=""
 RECIPIENT_WAID="" # Your WhatsApp number with country code (e.g., +31612345678)
-VERSION="v22.0"
-PHONE_NUMBER_ID=""
+VERSION="v22.0" # Meta Graph API version
+PHONE_NUMBER_ID="" # Your WhatsApp Business Phone Number ID
 
+# Webhook Verification Token (must match the one in Meta App Dashboard)
 VERIFY_TOKEN=""
 
-SERIVCE="" # Options: openai, azure_openai
+# ---------------------------------------------------------------------------
+# Chat API Provider Configuration
+# ---------------------------------------------------------------------------
+# Determines which chat API service to use. Options: "OPENAI", "AZURE".
+# Defaults to "OPENAI" if not set.
+CHAT_API_PROVIDER="OPENAI"
 
-OPENAI_API_KEY=""
-OPENAI_ASSISTANT_ID=""
+# --- OpenAI Configuration (if CHAT_API_PROVIDER="OPENAI") ---
+OPENAI_API_KEY="" # Required
+OPENAI_MODEL_NAME="" # Required (e.g., gpt-3.5-turbo, gpt-4o-mini)
+OPENAI_API_BASE="" # Optional: Use if you have a custom API endpoint or proxy
+OPENAI_EMBEDDING_MODEL_NAME="text-embedding-3-small" # Optional: Defaults to text-embedding-3-small
+# OPENAI_ASSISTANT_ID="" # Optional: If using OpenAI Assistants API features elsewhere in the application
 
-AZURE_OPENAI_ENDPOINT=""
-AZURE_OPENAI_API_KEY=""
-AZURE_OPENAI_API_VERSION=""
-AZURE_OPENAI_DEPLOYMENT_NAME=""
+# --- Azure OpenAI Configuration (if CHAT_API_PROVIDER="AZURE") ---
+AZURE_OPENAI_ENDPOINT="" # Required (e.g., https://your-resource-name.openai.azure.com)
+AZURE_OPENAI_API_KEY="" # Required
+AZURE_OPENAI_DEPLOYMENT_NAME="" # Required (Name of your chat model deployment, e.g., gpt4-turbo)
+AZURE_OPENAI_API_VERSION="2024-02-15-preview" # Optional: API version, defaults to 2024-02-15-preview
+AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME="" # Optional: Name of your embedding model deployment (defaults to chat deployment name if not set)
+
+# Note: For a local vLLM setup (future), you might set CHAT_API_PROVIDER="VLLM"
+# and add variables like VLLM_API_BASE="http://localhost:8000/v1" and VLLM_MODEL_NAME="your-model".


### PR DESCRIPTION
## Summary
This PR introduces a unified chat service module and updates configuration to support multiple API providers, including placeholders for local VLLM.

**Key changes:**
*   Consolidates OpenAI and Azure OpenAI API integrations into `app/services/openai_service.py`.
*   Introduces the `CHAT_API_PROVIDER` environment variable to dynamically select the chat API service (current options: `OPENAI`, `AZURE`; planned: `VLLM`).
*   Updates `example.env` with `CHAT_API_PROVIDER`, clear configuration sections for OpenAI and Azure, and commented-out placeholder variables for a local vLLM setup.
*   Modifies `CLAUDE.md` to reflect the new unified service architecture and the redundancy of the previous `azure_openai_service.py`.

**Benefits:**
*   Eliminates code duplication.
*   Simplifies chat API configuration.
*   Renders `app/services/azure_openai_service.py` redundant.
*   Enhances extensibility for future API providers like local vLLM.

## Test plan
1.  Set up the `.env` file with one of the following configurations:
    *   `CHAT_API_PROVIDER="OPENAI"`, along with valid `OPENAI_API_KEY` and `OPENAI_MODEL_NAME`.
    *   `CHAT_API_PROVIDER="AZURE"`, along with valid Azure credentials (`AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_DEPLOYMENT_NAME`).
2.  Run the application using `python run.py`.
3.  Send a message to the configured WhatsApp bot.
4.  **Expected Result:** The bot should respond, utilizing the API provider configured in the `.env` file.
5.  Test with an invalid `CHAT_API_PROVIDER` value (e.g., `CHAT_API_PROVIDER="INVALID_SERVICE"`).
6.  **Expected Result:** The application should raise a `ValueError` upon startup, indicating an unsupported provider.
7.  (Optional) If `app/services/azure_openai_service.py` still exists, manually delete it. Confirm the application continues to function correctly with both `OPENAI` and `AZURE` provider settings.
8.  Review `example.env` to ensure the VLLM placeholder variables are clear and correctly commented.